### PR TITLE
Fix #5 Added status definition for GV21

### DIFF
--- a/profile/nodedef/nodedef.xml
+++ b/profile/nodedef/nodedef.xml
@@ -17,6 +17,7 @@
       <st id="SOLRAD" editor="SOLARRAD" />
       <st id="GV16" editor="UV" />
       <st id="GV17" editor="AQI" />
+      <st id="GV21" editor="DEBUG" hide="T"/>
     </sts>
     <cmds>
       <sends />


### PR DESCRIPTION
Added Debug status value to fix init value. fixes  #5 
Debug status is being reported to isy (/rest/nodes/xxxx) so the only thing needed to fix init is status definition.  Also prevents empty cursor during status query.

<properties>
....
<property id="GV21" value="0" formatted="0" uom="25"/>
....
</properties>